### PR TITLE
Resolve #39

### DIFF
--- a/rootfs/nginx/sites-enabled/nginx.conf
+++ b/rootfs/nginx/sites-enabled/nginx.conf
@@ -3,6 +3,7 @@ server {
         root /nextcloud;
         
         fastcgi_buffers 64 4K;
+        large_client_header_buffers 4 16k;
 
         # https://docs.nextcloud.com/server/14/admin_manual/configuration_server/harden_server.html?highlight=security#enable-http-strict-transport-security
         add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload";


### PR DESCRIPTION
Add `large_client_header_buffers 4 16k` to `nginx.conf`. For example, allows bigger cookies to be sent through chrome browser.